### PR TITLE
Added possibility to use arrays in group_source_config mappings

### DIFF
--- a/conf/authshibboleth.conf.php
+++ b/conf/authshibboleth.conf.php
@@ -103,7 +103,8 @@ $conf['plugin']['authshibboleth'] = array(
                 'source_attribute' => 'entitlement',
                 'map' => array(
                     'entitlement1' => 'group1',
-                    'entitlement2' => 'group2'
+                    'entitlement2' => 'group2',
+                    'entitlement3' => ['group3', 'group4']
                 ),
                 'prefix' => 'ent:'
             )

--- a/plugin/authshibboleth/auth.php
+++ b/plugin/authshibboleth/auth.php
@@ -649,7 +649,15 @@ class auth_plugin_authshibboleth extends DokuWiki_Auth_Plugin
                 $group = $sourceOptions['prefix'] . $group;
             }
             
-            $groups[] = $group;
+            // Allow arrays in mapping
+            if (is_array($group)) {
+                foreach ($group as $value) {
+                    $groups[] = $value;
+                }
+            }
+            else {
+                $groups[] = $group;
+            }
         }
         
         return $groups;

--- a/plugin/authshibboleth/auth.php
+++ b/plugin/authshibboleth/auth.php
@@ -644,19 +644,23 @@ class auth_plugin_authshibboleth extends DokuWiki_Auth_Plugin
                     $group = $map[$group];
                 }
             }
-            
-            if (isset($sourceOptions['prefix'])) {
-                $group = $sourceOptions['prefix'] . $group;
-            }
-            
+                        
             // Allow arrays in mapping
             if (is_array($group)) {
                 foreach ($group as $value) {
+                if (isset($sourceOptions['prefix'])) {
+                   $groups[] = $sourceOptions['prefix'] . $value;
+                } else {
                     $groups[] = $value;
+                }
                 }
             }
             else {
-                $groups[] = $group;
+                if (isset($sourceOptions['prefix'])) {
+                   $groups[] = $sourceOptions['prefix'] . $group;
+                } else {
+                    $groups[] = $group;
+                }
             }
         }
         


### PR DESCRIPTION
I was missing the possibility to have arrays in the group_source_config mappings (e.g. when you are in the group "IT" and want to map that to the Dokuwiki-groups "it" and "admin"), so changes were made in auth.php